### PR TITLE
Fix trigger colorscheme autocommand

### DIFF
--- a/autoload/thematic.vim
+++ b/autoload/thematic.vim
@@ -166,11 +166,13 @@ function! thematic#init(mode) abort
   let l:cs = get(l:th, 'colorscheme', l:theme_name)
   try
     execute 'colorscheme ' . l:cs
+    doautoall colorscheme
   catch /E185:/
     " no colorscheme matching the theme name, so fall back to original, if any
     if has_key(g:thematic#original, 'colorscheme')
       let l:cs = g:thematic#original.colorscheme
       execute 'colorscheme ' . l:cs
+      doautoall colorscheme
     endif
   endtry
 


### PR DESCRIPTION
Some plugins like vim-coc rely on the colorscheme autocommand to apply their overrides to themes. Because we're using `execute` instead of calling `colorscheme` directly, we have to manually trigger the event.